### PR TITLE
Just a little Dzil/GitHub niceness.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -11,3 +11,7 @@ version = 0.001
 [TestRelease]
 [ConfirmRelease]
 
+[ReadmeAnyFromPod / pod.root ]
+    filename = README.pod
+    type = pod
+    location = root


### PR DESCRIPTION
Make GitHub happier by making a README.pod. It is generated every time you `dzil build` and survives `dzil clean`. Created from the POD in the primary .pm file.

Ignore if you want, but I find it useful and no extra work.
